### PR TITLE
#8 - Main Contents action 구현 및 탭 관련 action 적용 및 

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2485,6 +2485,11 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
+    "boost-mathquill": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/boost-mathquill/-/boost-mathquill-1.0.7.tgz",
+      "integrity": "sha512-INvvdgVvtYxJEQqBzTw1IUBbtCgpQd0fbNx27qNkRzB3xBlKeEXDiz3seDSdDqxfmvHrwPNVI23QwydNXB7Hpw=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -7394,11 +7399,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "react-mathquill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-mathquill/-/react-mathquill-1.0.1.tgz",
-      "integrity": "sha512-r49RWfHPSyEgGDHdq6khOO5MWtqFhDxtrhGNdHxmuwgpx+pB9+NiIF+QolvIyea0FMkVmyzsC6R3jjK8oK6skQ=="
     },
     "react-popper": {
       "version": "2.2.4",

--- a/client/package.json
+++ b/client/package.json
@@ -21,11 +21,11 @@
     "@types/react-frame-component": "^4.1.1",
     "@types/react-redux": "^7.1.11",
     "axios": "^0.21.0",
+    "boost-mathquill": "^1.0.7",
     "emotion": "^11.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-frame-component": "^4.1.3",
-    "react-mathquill": "^1.0.1",
     "react-redux": "^7.2.2",
     "redux": "^4.0.5"
   },

--- a/client/public/content.css
+++ b/client/public/content.css
@@ -54,16 +54,17 @@ body {
 }
 .mq-editable-field,
 .mq-math-mode .mq-editable-field {
-  border: 1px solid gray;
+  width: 100%;
+  padding: 0 5px;
 }
-.mq-editable-field.mq-focused,
+/* .mq-editable-field.mq-focused,
 .mq-math-mode .mq-editable-field.mq-focused {
   -webkit-box-shadow: #8bd 0 0 1px 2px, inset #6ae 0 0 2px 0;
   -moz-box-shadow: #8bd 0 0 1px 2px, inset #6ae 0 0 2px 0;
   box-shadow: #8bd 0 0 1px 2px, inset #6ae 0 0 2px 0;
   border-color: #709ac0;
   border-radius: 1px;
-}
+} */
 .mq-math-mode .mq-editable-field {
   margin: 1px;
 }

--- a/client/src/components/Ingredients/TextAreaItem/index.tsx
+++ b/client/src/components/Ingredients/TextAreaItem/index.tsx
@@ -1,8 +1,19 @@
 import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { TextArea } from './style';
+import { RootState } from '../../../contexts';
+import { editLatex } from '../../../contexts/latex';
 
 function TextAreaItem() {
-  return <TextArea />;
+  const dispatch = useDispatch();
+  const { currentTab, totalLatex } = useSelector((state: RootState) => state.latex);
+  const currentText = totalLatex.filter((tabinfo) => tabinfo.id === currentTab)[0].latex;
+
+  const onChangeHandler = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    dispatch(editLatex(e.target.value));
+  };
+
+  return <TextArea value={currentText} onChange={onChangeHandler} />;
 }
 
-export default TextArea;
+export default TextAreaItem;

--- a/client/src/components/Meal/OutputContents/index.tsx
+++ b/client/src/components/Meal/OutputContents/index.tsx
@@ -10,9 +10,7 @@ function OutputContents() {
       <S.ContentsHeader>
         <TemplateButtons></TemplateButtons>
       </S.ContentsHeader>
-      <S.ContentsBox>
-        <Content></Content>
-      </S.ContentsBox>
+      <Content />
     </S.ContentsContainer>
   );
 }

--- a/client/src/components/Meal/OutputContents/style.ts
+++ b/client/src/components/Meal/OutputContents/style.ts
@@ -10,10 +10,3 @@ export const ContentsContainer = styled.div`
 export const ContentsHeader = styled.div`
   flex-basis: 50px;
 `;
-
-export const ContentsBox = styled.div`
-  border: 1px solid #d4d4d5;
-  border-radius: 0 5px 5px 5px;
-  height: 100%;
-  padding: 7px;
-`;

--- a/client/src/components/Meal/Tab/index.tsx
+++ b/client/src/components/Meal/Tab/index.tsx
@@ -29,7 +29,9 @@ function Tab() {
           }
         })}
       </Menu>
-      <Button icon={'plus'} size={'mini'} handler={addTabHandler}></Button>
+      {totalLatex.length < 4 && (
+        <Button icon={'plus'} size={'mini'} handler={addTabHandler}></Button>
+      )}
     </TabContainer>
   );
 }

--- a/client/src/components/Set/Main/Content.tsx
+++ b/client/src/components/Set/Main/Content.tsx
@@ -1,45 +1,33 @@
-import React, { useMemo, useState } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { editLatex, initLatex } from '../../../contexts/latex';
 import { RootState } from '../../../contexts/index';
-import { EditableMathField, MathField, StaticMathField } from 'react-mathquill';
+import { EditableMathField, MathField } from 'boost-mathquill';
+import { ContentsBox } from './style';
 
 function Content() {
   const dispatch = useDispatch();
-
-  const { currentTab, totalLatex } = useSelector((state: RootState) => state.latex);
-  const [mathfieldInput, setMathfieldInput] = useState<MathField | null>(null);
+  const { currentTab, totalLatex, mathfield } = useSelector((state: RootState) => state.latex);
   const nowLatexInfo = totalLatex.filter((latex) => latex.id === currentTab)[0];
 
-  const injectMathFunction = (latexString: any) => {
-    if (mathfieldInput) {
-      mathfieldInput.write(latexString);
-    }
-  };
   const initmathInput = (mathField: MathField) => {
     dispatch(initLatex(mathField));
-    setMathfieldInput(mathField);
+  };
+  const onChangeHandler = (mathField: MathField) => {
+    dispatch(editLatex(mathField.latex()));
+  };
+  const onClickHandler = () => {
+    if (mathfield) mathfield.focus();
   };
 
   return (
-    <div>
+    <ContentsBox onClick={onClickHandler}>
       <EditableMathField
         mathquillDidMount={initmathInput}
-        latex={nowLatexInfo.latex} // latex value for the input field
-        onChange={(mathField: MathField) => {
-          dispatch(editLatex(mathField.latex()));
-          // setLatex(mathField.latex());
-          mathField.focus();
-        }}
+        latex={nowLatexInfo.latex}
+        onChange={onChangeHandler}
       />
-      {/* <StaticMathField>{'\\lim _{\\combi{ }\\to \\combi{ }}^{ }\\combi{ }'}</StaticMathField> */}
-      {/* <button onClick={() => injectMathFunction('\\sqrt{}')}>√</button>
-      <button onClick={() => injectMathFunction('\\cos{}')}>cos</button>
-      <button onClick={() => injectMathFunction('\\alpha')}>alpha</button>
-      <button onClick={() => injectMathFunction('\\fleft( x \right)')}>func</button>
-      <button onClick={() => injectMathFunction('\\iint{ }')}>int</button> */}
-      <p>{nowLatexInfo.latex}</p>
-    </div>
+    </ContentsBox>
   );
 }
 export default Content;

--- a/client/src/components/Set/Main/style.ts
+++ b/client/src/components/Set/Main/style.ts
@@ -4,4 +4,13 @@ const MainContainer = styled.div`
   height: 100%;
   display: flex;
 `;
+
+export const ContentsBox = styled.div`
+  border: 1px solid #d4d4d5;
+  border-radius: 0 5px 5px 5px;
+  height: 100%;
+  padding: 7px;
+  position: relative;
+`;
+
 export default MainContainer;

--- a/client/src/contexts/latex/actions.ts
+++ b/client/src/contexts/latex/actions.ts
@@ -1,4 +1,4 @@
-import { MathField } from 'react-mathquill';
+import { MathField } from 'boost-mathquill';
 import { createAction } from '../../lib/utils/util';
 //TODO: 리팩토링 하기
 

--- a/client/src/contexts/latex/types.ts
+++ b/client/src/contexts/latex/types.ts
@@ -1,4 +1,4 @@
-import { MathField } from 'react-mathquill';
+import { MathField } from 'boost-mathquill';
 import { addTab, changeTab, editLatex, removeTab } from './actions';
 import { initLatex } from './actions';
 

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import { createStore, applyMiddleware } from 'redux';
 import rootReducer from './contexts';
 import logger from 'redux-logger';
-import { composeWithDevTools } from 'redux-devtools-extension';
+// import { composeWithDevTools } from 'redux-devtools-extension';
 // import '../public/root.css';
 
 // const app = document.createElement('div');
@@ -26,7 +26,7 @@ import { composeWithDevTools } from 'redux-devtools-extension';
 //     app.style.display = 'none';
 //   }
 // }
-const store = createStore(rootReducer, composeWithDevTools());
+const store = createStore(rootReducer, applyMiddleware(logger));
 
 ReactDOM.render(
   <Provider store={store}>


### PR DESCRIPTION
## 관련 이슈
- Tex 문법 수식 입력 #8 
- 탭(페이지) 추가 #28 
- 탭(페이지) 삭제 #29 

## 구현한 내용
- Main Contents의 오른쪽 스타일 수정
- Main Contents의 왼쪽 Tex 입력창 Action 적용
- Tab 관련 action 적용

## 실행 화면
![image](https://user-images.githubusercontent.com/23556120/100363585-4777b600-3040-11eb-97f7-a1672f48072b.png)
