### PR TITLE
#13 - 드롭다운 수식 리스트의 스타일 수정

### DIFF
--- a/client/public/content.css
+++ b/client/public/content.css
@@ -1,4 +1,4 @@
-body {
+* {
   margin: 0;
   padding: 0;
   box-sizing: border-box;

--- a/client/src/components/Ingredients/DropDownItem/index.tsx
+++ b/client/src/components/Ingredients/DropDownItem/index.tsx
@@ -14,11 +14,10 @@ function DropDownItem({ children, onMouseOver, latex, setNowFormula }: DropDownI
     setNowFormula(latex.content);
   };
 
-  return (
-    <S.DropDownItemStyle header={latex.header} onMouseOver={customMouseOver}>
-      {children}
-    </S.DropDownItemStyle>
-  );
+  if (children) {
+    return <S.DropDownItemStyle onMouseOver={customMouseOver}>{children}</S.DropDownItemStyle>;
+  }
+  return <S.DropDownItemStyle header={latex.header} onMouseOver={customMouseOver} />;
 }
 
 export default DropDownItem;

--- a/client/src/components/Ingredients/DropDownItem/index.tsx
+++ b/client/src/components/Ingredients/DropDownItem/index.tsx
@@ -4,14 +4,22 @@ import * as S from './style';
 interface DropDownItemProps {
   children?: ReactChildren | string;
   onMouseOver: (e: React.MouseEvent) => void;
+  setNowHeader: (header: string) => void;
   setNowFormula: (formula: LatexContent[]) => void;
   latex: LatexHeader;
 }
 
-function DropDownItem({ children, onMouseOver, latex, setNowFormula }: DropDownItemProps) {
+function DropDownItem({
+  children,
+  onMouseOver,
+  latex,
+  setNowHeader,
+  setNowFormula,
+}: DropDownItemProps) {
   const customMouseOver = (e: React.MouseEvent) => {
     onMouseOver(e);
     setNowFormula(latex.content);
+    setNowHeader(latex.header);
   };
 
   if (children) {

--- a/client/src/components/Ingredients/DropDownItem/style.ts
+++ b/client/src/components/Ingredients/DropDownItem/style.ts
@@ -7,6 +7,7 @@ export const DropDownItemStyle = styled.button<DropDownItemStyleProps>`
   background: url(${(props) => `./image/${props.header}`});
   width: 60px;
   height: 60px;
+  padding-bottom: 6px;
   font-size: 2rem;
   font-weight: bold;
   background-position: center;

--- a/client/src/components/Ingredients/DropDownItem/style.ts
+++ b/client/src/components/Ingredients/DropDownItem/style.ts
@@ -1,12 +1,14 @@
 import styled from '@emotion/styled';
 interface DropDownItemStyleProps {
-  header: string;
+  header?: string;
 }
 
 export const DropDownItemStyle = styled.button<DropDownItemStyleProps>`
   background: url(${(props) => `./image/${props.header}`});
   width: 60px;
-  height: 100%;
+  height: 60px;
+  font-size: 2rem;
+  font-weight: bold;
   background-position: center;
   cursor: pointer;
   border: 4px solid transparent;

--- a/client/src/components/Ingredients/FormulaItem/index.tsx
+++ b/client/src/components/Ingredients/FormulaItem/index.tsx
@@ -4,8 +4,16 @@ import * as S from './style';
 
 function FormulaItem({ latexInfo, hiddenFormula }: FormulaItemProps) {
   const { onClick } = useFormulaItem({ latexInfo, hiddenFormula });
+  const isSvg = latexInfo.image.includes('svg');
 
-  return <S.FormulaItem onClick={onClick} image={latexInfo.image}></S.FormulaItem>;
+  if (isSvg) {
+    return <S.FormulaItem onClick={onClick} isSvg={isSvg} image={latexInfo.image}></S.FormulaItem>;
+  }
+  return (
+    <S.FormulaItem onClick={onClick} isSvg={isSvg}>
+      {latexInfo.image}
+    </S.FormulaItem>
+  );
 }
 
 export default FormulaItem;

--- a/client/src/components/Ingredients/FormulaItem/style.ts
+++ b/client/src/components/Ingredients/FormulaItem/style.ts
@@ -1,19 +1,29 @@
 import styled from '@emotion/styled';
 interface FormulaItemStyleProps {
-  image: string;
+  image?: string;
+  isSvg: boolean;
 }
 
-export const FormulaItem = styled.button<FormulaItemStyleProps>`
+export const FormulaItem = styled.li<FormulaItemStyleProps>`
   background: url(${(props) => `./image/${props.image}`});
-  width: ${(props) => (props.image.includes('b') ? '140px' : '70px')};
-  height: 70px;
+  background-size: 100%;
+  width: ${(props) => (!props.isSvg ? '35px' : props.image?.includes('b') ? '140px' : '70px')};
+  height: ${(props) => (!props.isSvg ? '35px' : '70px')};
+  font-size: 1rem;
+  text-align: center;
+  line-height: 35px;
   background-position: center;
   cursor: pointer;
   border: none;
   border-right: 0.5px solid #d5d5d5;
   border-bottom: 0.5px solid #d5d5d5;
   background-repeat: no-repeat;
+  transition: font-size 0.3s, color 0.3s, background-size 0.3s;
+
   &:hover {
-    border: 4px dashed #6d9eeb;
+    background-size: 120%;
+    border: 0.5px solid black;
+    filter: invert(63%) sepia(13%) saturate(2335%) hue-rotate(87deg) brightness(91%) contrast(83%);
+    font-size: 1.5rem;
   }
 `;

--- a/client/src/components/Meal/FormulaList/index.tsx
+++ b/client/src/components/Meal/FormulaList/index.tsx
@@ -13,6 +13,8 @@ function FormulaList() {
     clearHiddenTimemout,
     hiddenFormula,
     reserveHiddenFormula,
+    nowHeader,
+    setNowHeader,
     nowFormulas,
     setNowFormula,
   } = useFormulaList();
@@ -30,6 +32,7 @@ function FormulaList() {
               latex={latex}
               key={index}
               onMouseOver={displayFormula}
+              setNowHeader={setNowHeader}
               setNowFormula={setNowFormula}
             ></DropDownItem>
           ))}
@@ -41,6 +44,7 @@ function FormulaList() {
               latex={latex}
               key={index}
               onMouseOver={displayFormula}
+              setNowHeader={setNowHeader}
               setNowFormula={setNowFormula}
             >
               {latex.header}
@@ -54,6 +58,7 @@ function FormulaList() {
         onMouseLeave={hiddenFormula}
         onMouseOver={clearHiddenTimemout}
         length={nowFormulas.length}
+        header={nowHeader}
       >
         {nowFormulas.map((latexInfo, index) => (
           <FormulaItem

--- a/client/src/components/Meal/FormulaList/index.tsx
+++ b/client/src/components/Meal/FormulaList/index.tsx
@@ -42,12 +42,19 @@ function FormulaList() {
               key={index}
               onMouseOver={displayFormula}
               setNowFormula={setNowFormula}
-            ></DropDownItem>
+            >
+              {latex.header}
+            </DropDownItem>
           ))}
         </S.SymbolHeaderWrapper>
       </S.FormulaContainer>
 
-      <S.Contents ref={formulaRef} onMouseLeave={hiddenFormula} onMouseOver={clearHiddenTimemout}>
+      <S.FormulaList
+        ref={formulaRef}
+        onMouseLeave={hiddenFormula}
+        onMouseOver={clearHiddenTimemout}
+        length={nowFormulas.length}
+      >
         {nowFormulas.map((latexInfo, index) => (
           <FormulaItem
             key={index}
@@ -55,7 +62,7 @@ function FormulaList() {
             hiddenFormula={hiddenFormula}
           ></FormulaItem>
         ))}
-      </S.Contents>
+      </S.FormulaList>
     </>
   );
 }

--- a/client/src/components/Meal/FormulaList/style.ts
+++ b/client/src/components/Meal/FormulaList/style.ts
@@ -15,6 +15,7 @@ export const FormulaHeaderWrapper = styled.div`
   border-bottom-left-radius: 10px;
   padding: 0.3rem;
   overflow-x: auto;
+  overflow-y: hidden;
   white-space: nowrap;
   padding-right: 20px;
 `;
@@ -32,16 +33,21 @@ export const SymbolHeaderWrapper = styled.div`
   padding-left: 10px;
 `;
 
-export const Contents = styled.div`
+interface FormulaListFrops {
+  length: number;
+}
+
+export const FormulaList = styled.ul<FormulaListFrops>`
   display: none;
-  border: 1px solid #bdbdbd;
   flex-wrap: wrap;
-  background: #eaeaea;
-  width: 70%;
-  max-width: 983px;
-  margin: 10px auto;
+  max-width: ${(props) => (props.length > 20 ? '712px' : '702px')};
+  max-height: 142px;
   position: relative;
+  margin: 10px auto;
+  padding: 0;
+  border: 1px solid #bdbdbd;
+  background: #eaeaea;
   overflow-y: auto;
-  max-height: 160px;
   z-index: 99999;
+  list-style: none;
 `;

--- a/client/src/components/Meal/FormulaList/style.ts
+++ b/client/src/components/Meal/FormulaList/style.ts
@@ -10,6 +10,9 @@ export const FormulaContainer = styled.div`
 `;
 
 export const FormulaHeaderWrapper = styled.div`
+  height: 100%;
+  display: flex;
+  align-items: center;
   border-right: 1px solid #d4d4d5;
   border-top-left-radius: 10px;
   border-bottom-left-radius: 10px;
@@ -19,13 +22,18 @@ export const FormulaHeaderWrapper = styled.div`
   white-space: nowrap;
   padding-right: 20px;
 `;
+
 export const SymbolHeaderWrapper = styled.div`
+  height: 100%;
+  display: flex;
+  align-items: center;
   margin-left: 3px;
   border-left: 1px solid #d4d4d5;
   border-top-right-radius: 10px;
   border-bottom-right-radius: 10px;
   padding: 0.3rem;
   overflow-x: auto;
+  overflow-y: hidden;
   white-space: nowrap;
   & button {
     background-size: contain;
@@ -34,13 +42,22 @@ export const SymbolHeaderWrapper = styled.div`
 `;
 
 interface FormulaListFrops {
+  header: string;
   length: number;
 }
 
 export const FormulaList = styled.ul<FormulaListFrops>`
   display: none;
   flex-wrap: wrap;
-  max-width: ${(props) => (props.length > 20 ? '712px' : '702px')};
+  // TODO: 반응형으로 브라우저 좌우 크기 줄어들 때 크기 다 constants에 상수화
+  max-width: ${(props) =>
+    props.header.includes('svg')
+      ? props.length > 20
+        ? '712px'
+        : '702px'
+      : props.length > 60
+      ? '712px'
+      : '702px'};
   max-height: 142px;
   position: relative;
   margin: 10px auto;

--- a/client/src/components/Meal/FormulaList/useFormulaList.ts
+++ b/client/src/components/Meal/FormulaList/useFormulaList.ts
@@ -5,6 +5,7 @@ const useFormulaList = () => {
   const formulaRef = useRef<null | HTMLUListElement>(null);
   const containerRef = useRef<null | HTMLDivElement>(null);
   const timer = useRef<any>(null);
+  const [nowHeader, setNowHeader] = useState<string>('');
   const [nowFormulas, setNowFormula] = useState<LatexContent[]>([]);
 
   const displayFormula = () => {
@@ -41,6 +42,8 @@ const useFormulaList = () => {
     containerRef,
     nowFormulas,
     setNowFormula,
+    nowHeader,
+    setNowHeader,
     displayFormula,
     clearHiddenTimemout,
     hiddenFormula,

--- a/client/src/components/Meal/FormulaList/useFormulaList.ts
+++ b/client/src/components/Meal/FormulaList/useFormulaList.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { LatexContent } from '../../../lib/constants/latex-header';
 
 const useFormulaList = () => {
-  const formulaRef = useRef<null | HTMLHeadingElement>(null);
+  const formulaRef = useRef<null | HTMLUListElement>(null);
   const containerRef = useRef<null | HTMLDivElement>(null);
   const timer = useRef<any>(null);
   const [nowFormulas, setNowFormula] = useState<LatexContent[]>([]);

--- a/client/src/components/Set/Header/style.ts
+++ b/client/src/components/Set/Header/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
 const header = styled.div`
-  height: 20vh;
+  height: 74px;
 `;
 export default header;

--- a/client/src/lib/constants/latex-header.ts
+++ b/client/src/lib/constants/latex-header.ts
@@ -575,19 +575,19 @@ const FORMULA_HEADER: LatexHeader[] = [
         latex: `\\lim _{n\\to \\infty }^{ }\\combi{ }`,
       },
       {
-        image: `/9/10-b.svg`,
-        latex: `\\lim _{n\\to \\infty }^{ }\\left(a_n\\pm b_n\\right)`,
-      },
-      {
         image: `/9/11.svg`,
         latex: `\\lim _{\\righttriangle x\\to 0}^{ }\\frac{\\righttriangle y}{\\righttriangle x}`,
       },
       {
-        image: `/9/12.svg`,
+        image: `/9/10-b.svg`,
+        latex: `\\lim _{n\\to \\infty }^{ }\\left(a_n\\pm b_n\\right)`,
+      },
+      {
+        image: `/9/12-b.svg`,
         latex: `\\lim _{n\\to \\infty }^{ }\\left(1+\\frac{1}{n}\\right)^n`,
       },
       {
-        image: `/9/13.svg`,
+        image: `/9/13-b.svg`,
         latex: `\\lim _{n\\to \\infty }^{ }\\sum _{k=1}^n\\combi{ }`,
       },
     ],
@@ -778,28 +778,260 @@ const FORMULA_HEADER: LatexHeader[] = [
 
 const SYMBOL_HEADER: LatexHeader[] = [
   {
-    header: `12-btn.svg`,
+    header: `+`,
+    content: [
+      {
+        image: '+',
+        latex: `+`,
+      },
+      {
+        image: '−',
+        latex: `−`,
+      },
+      {
+        image: '×',
+        latex: `\\times`,
+      },
+      {
+        image: '÷',
+        latex: `\\div`,
+      },
+      {
+        image: '±',
+        latex: `\\pm`,
+      },
+      {
+        image: '∓',
+        latex: `\\mp`,
+      },
+      {
+        image: '/',
+        latex: `/`,
+      },
+      {
+        image: '*',
+        latex: `*`,
+      },
+      {
+        image: '∘',
+        latex: `\\circ`,
+      },
+      {
+        image: '·',
+        latex: `\\cdot`,
+      },
+      {
+        image: '⋆',
+        latex: `\\star`,
+      },
+      {
+        image: '⋄',
+        latex: `\\diamond`,
+      },
+      {
+        image: '⊙',
+        latex: `\\odot`,
+      },
+      {
+        image: '⊗',
+        latex: `\\otimes`,
+      },
+      {
+        image: '⊕',
+        latex: `\\oplus`,
+      },
+      {
+        image: '⊖',
+        latex: `\\ominus`,
+      },
+      {
+        image: '⊘',
+        latex: `\\oslash`,
+      },
+      {
+        image: '∩',
+        latex: `\\cap`,
+      },
+      {
+        image: '∪',
+        latex: `\\cup`,
+      },
+      {
+        image: '⋒',
+        latex: `\\Cap`,
+      },
+
+      {
+        image: '⋓',
+        latex: `\\Cup`,
+      },
+      {
+        image: '⊎',
+        latex: `\\plusunion`,
+      },
+      {
+        image: '⊓',
+        latex: `\\sqcap`,
+      },
+      {
+        image: '⊔',
+        latex: `\\wedge`,
+      },
+      {
+        image: '∧',
+        latex: `\\wedge`,
+      },
+      {
+        image: '∨',
+        latex: `\\vee`,
+      },
+      {
+        image: 'Σ',
+        latex: `\\Sigma`,
+      },
+      {
+        image: '∫',
+        latex: `\\sint`,
+      },
+      {
+        image: '∬',
+        latex: `\\siint`,
+      },
+      {
+        image: '∭',
+        latex: `\\siiint`,
+      },
+      {
+        image: '∮',
+        latex: `\\soint`,
+      },
+      {
+        image: '∯',
+        latex: `\\soiint`,
+      },
+      {
+        image: '∰',
+        latex: `\\soiiint`,
+      },
+      {
+        image: '∱',
+        latex: `\\tint`,
+      },
+      {
+        image: '∲',
+        latex: `\\tlint`,
+      },
+      {
+        image: '∳',
+        latex: `\\ctlint`,
+      },
+      {
+        image: '∇',
+        latex: `\\nabla`,
+      },
+      {
+        image: '∏',
+        latex: `\\sprod`,
+      },
+      {
+        image: '∐',
+        latex: `\\amalg`,
+      },
+      {
+        image: '∩',
+        latex: `\\lcap`,
+      },
+      {
+        image: '∪',
+        latex: `\\lcup`,
+      },
+      {
+        image: '⋀',
+        latex: `\\And`,
+      },
+      {
+        image: '⋁',
+        latex: `\\Or`,
+      },
+      {
+        image: '⨄',
+        latex: `\\uplus`,
+      },
+
+      {
+        image: '⨃',
+        latex: `\\dotunion`,
+      },
+      {
+        image: '∔',
+        latex: `\\dotplus`,
+      },
+      {
+        image: '∸',
+        latex: `\\dotminus`,
+      },
+      {
+        image: '∖',
+        latex: `\\setminus`,
+      },
+      {
+        image: '⋇',
+        latex: `\\dm`,
+      },
+      {
+        image: '⋉',
+        latex: `\\ltimes`,
+      },
+      {
+        image: '⋊',
+        latex: `\\rtimes`,
+      },
+      {
+        image: 'Ｔ',
+        latex: `\\top`,
+      },
+      {
+        image: '≀',
+        latex: `\\wr`,
+      },
+      {
+        image: '†',
+        latex: `\\dagger`,
+      },
+      {
+        image: '‡',
+        latex: `\\ddagger`,
+      },
+      {
+        image: '∞',
+        latex: `\\infty`,
+      },
+      {
+        image: '∅',
+        latex: `\\dotminus`,
+      },
+    ],
+  },
+  {
+    header: `+`,
     content: [],
   },
   {
-    header: `13-btn.svg`,
+    header: `+`,
     content: [],
   },
   {
-    header: `14-btn.svg`,
+    header: `+`,
     content: [],
   },
   {
-    header: `15-btn.svg`,
+    header: `+`,
     content: [],
   },
   {
-    header: `16-btn.svg`,
-    content: [],
-  },
-  {
-    header: `17-btn.svg`,
+    header: `+`,
     content: [],
   },
 ];
+
 export { FORMULA_HEADER, SYMBOL_HEADER, LatexHeader, LatexContent };

--- a/client/src/lib/constants/latex-header.ts
+++ b/client/src/lib/constants/latex-header.ts
@@ -8,6 +8,7 @@ interface LatexContent {
   image: string;
   latex: string | any;
 }
+
 const FORMULA_HEADER: LatexHeader[] = [
   {
     header: `1-btn.svg`,


### PR DESCRIPTION
## 관련 이슈
- 수식 선택 드롭다운 UI 구현 #13 

## 구현한 내용
- 수식 선택 헤더의 버튼들 상하 가운데 정렬
- 드롭다운 수식 리스트의 스크롤바 관련 스타일 수정

## 실행 화면

![image](https://user-images.githubusercontent.com/23556120/100629214-617d0580-336c-11eb-9114-781f566c3707.png)
