### PR TITLE
#44 - 수식사전 디자인 수정

### DIFF
--- a/client/public/content.css
+++ b/client/public/content.css
@@ -110,11 +110,11 @@ body {
   display: -moz-inline-box;
   display: inline-block;
   width: 100%;
-  padding: 2px;
+  /* padding: 2px; */
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
-  white-space: nowrap;
+  /* white-space: nowrap; */
   overflow: hidden;
   vertical-align: middle;
 }
@@ -122,7 +122,7 @@ body {
   font-variant: normal;
   font-weight: normal;
   font-style: normal;
-  font-size: 115%;
+  /* font-size: 115%; */
   line-height: 1;
   display: -moz-inline-box;
   display: inline-block;

--- a/client/src/components/Ingredients/DictionaryItem/index.tsx
+++ b/client/src/components/Ingredients/DictionaryItem/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { StaticMathField } from 'boost-mathquill';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/contexts';
+import { Table } from 'semantic-ui-react';
 import * as S from './style';
 
 interface DictionaryItemProps {
@@ -16,9 +17,13 @@ function DictionaryItem({ latex }: DictionaryItemProps) {
   };
 
   return (
-    <S.DictionaryItem onClick={onClick}>
+    // <S.DictionaryItem onClick={onClick}>
+    //   {/* <StaticMathField>{latex}</StaticMathField> */}
+    //   dsfdsafsfsdafsdfdssfdsdfasdfsdfasafdsfdadsfsadfasdfsdfsdafsfs
+    // </S.DictionaryItem>
+    <Table.Cell onClick={onClick}>
       <StaticMathField>{latex}</StaticMathField>
-    </S.DictionaryItem>
+    </Table.Cell>
   );
 }
 

--- a/client/src/components/Ingredients/DictionaryItem/style.ts
+++ b/client/src/components/Ingredients/DictionaryItem/style.ts
@@ -1,16 +1,1 @@
 import styled from '@emotion/styled';
-
-export const DictionaryItem = styled.li`
-  border-bottom: 1px solid grey;
-  cursor: pointer;
-  padding: 5px;
-  width: 800px;
-
-  &:hover {
-    background: #f3f3f3;
-  }
-
-  & span {
-    cursor: pointer;
-  }
-`;

--- a/client/src/components/Meal/DictionaryItemList/index.tsx
+++ b/client/src/components/Meal/DictionaryItemList/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import DictionaryItem from '@ingredients/DictionaryItem';
 import { MenuLatex } from '@constants/latex-dictionary';
+import { Table } from 'semantic-ui-react';
 import * as S from './style';
 
 interface DictionaryItemListProps {
@@ -16,14 +17,21 @@ function DictionaryItemList({
 }: DictionaryItemListProps) {
   return (
     <S.DictionaryItemList>
-      {searchWord &&
-        searchedContent.map((dictionary: MenuLatex, index: number) => (
-          <DictionaryItem key={index} latex={dictionary.latex} />
-        ))}
-      {!searchWord &&
-        selectedContent.map((dictionary: MenuLatex, index: number) => (
-          <DictionaryItem key={index} latex={dictionary.latex} />
-        ))}
+      <Table celled fixed unstackable selectable>
+        <Table.Body>
+          {searchWord
+            ? searchedContent.map((dictionary: MenuLatex, index: number) => (
+                <Table.Row key={index}>
+                  <DictionaryItem latex={dictionary.latex} />
+                </Table.Row>
+              ))
+            : selectedContent.map((dictionary: MenuLatex, index: number) => (
+                <Table.Row key={index}>
+                  <DictionaryItem latex={dictionary.latex} />
+                </Table.Row>
+              ))}
+        </Table.Body>
+      </Table>
     </S.DictionaryItemList>
   );
 }

--- a/client/src/components/Meal/DictionaryItemList/style.ts
+++ b/client/src/components/Meal/DictionaryItemList/style.ts
@@ -1,9 +1,17 @@
 import styled from '@emotion/styled';
 
-export const DictionaryItemList = styled.ul`
-  max-width: 600px;
-  margin-top: 10px;
-  list-style: none;
-  overflow-y: auto;
-  height: 150px;
+export const DictionaryItemList = styled.div`
+  margin-top: 13px;
+  margin-right: 1px;
+  overflow: auto;
+  border: 1px solid rgba(34, 36, 38, 0.15);
+  border-radius: 7px;
+  height: 137px;
+  & td {
+    padding: 7px 15px !important;
+  }
+
+  & table {
+    border: none !important;
+  }
 `;

--- a/client/src/components/Meal/DictionaryTab/index.tsx
+++ b/client/src/components/Meal/DictionaryTab/index.tsx
@@ -25,7 +25,6 @@ function DictionaryTab() {
           onSelectHandler={onSelectHandler}
           onSearchHandler={onSearchHandler}
         />
-
         <DictionaryItemList
           searchWord={searchWord}
           searchedContent={searchedContent}

--- a/client/src/components/Meal/DictionaryTab/style.ts
+++ b/client/src/components/Meal/DictionaryTab/style.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
 
 export const DictionaryContainer = styled.div`
-  padding: 0 5px;
+  padding: 5px 5px 0 5px;
 `;

--- a/client/src/components/Meal/DictionaryTab/useDictionaryTab.ts
+++ b/client/src/components/Meal/DictionaryTab/useDictionaryTab.ts
@@ -1,21 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
 import useInput from '@hooks/useInput';
 import useSelect from '@hooks/useSelect';
-import {
-  LATEX_DICTIONARY,
-  DICTIONARY_MENU_TITLE,
-  MenuLatex,
-  DictionaryMenu,
-} from '@constants/latex-dictionary';
+import { LATEX_DICTIONARY, DICTIONARY_MENU_TITLE, MenuLatex } from '@constants/latex-dictionary';
 
 const useDictionaryTab = () => {
   const [menuTitle, onChangeMenuTitle] = useSelect(DICTIONARY_MENU_TITLE.polynomial);
   const [searchWord, onChangeSearchWord, clearWord] = useInput('');
-  const [searchedContent, setSearchedContent] = useState<MenuLatex[]>([]);
 
   const currentMenu = LATEX_DICTIONARY.filter((dictionary) => dictionary.menu === menuTitle)[0];
-
-  let timer = useRef<any>();
+  const [searchedContent, setSearchedContent] = useState<MenuLatex[]>(currentMenu.content);
+  const timer = useRef<any>();
 
   const onSelectHandler = (event: React.ChangeEvent<HTMLSelectElement>) => {
     onChangeMenuTitle(event);

--- a/client/src/components/Meal/InputContents/index.tsx
+++ b/client/src/components/Meal/InputContents/index.tsx
@@ -24,7 +24,10 @@ const panes = [
   },
   {
     menuItem: '수식사전',
-    render: () => <DictionaryTab />,
+    // render: () => <DictionaryTab />,
+    render: function tabContent() {
+      return <DictionaryTab />;
+    },
   },
   {
     menuItem: '즐겨찾기',

--- a/client/src/components/Meal/PageTab/style.ts
+++ b/client/src/components/Meal/PageTab/style.ts
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 export const TabContainer = styled.div`
+  margin-top: 40px;
   display: flex;
   flex-direction: column;
   flex-shrink: 0;

--- a/client/src/components/Set/Input/style.ts
+++ b/client/src/components/Set/Input/style.ts
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 export const InputAreaContainer = styled.div`
   height: 100%;
   display: flex;
-  flex-grow: 4;
+  width: 57%;
   min-width: 480px;
   margin-right: 15px;
 `;

--- a/client/src/components/Set/Output/style.ts
+++ b/client/src/components/Set/Output/style.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 export const OutputAreaContainer = styled.div`
   height: 100%;
-  flex-grow: 5;
+  width: 43%;
   min-width: 330px;
   margin-left: 15px;
 `;


### PR DESCRIPTION
## 수식사전 디자인 수정
- 수식사전 디자인 수정
- 수식사전 버그 리팩토링

## 실행 화면
![image](https://user-images.githubusercontent.com/52816790/100965763-c011d180-356e-11eb-9672-82912d21849f.png)

## 논의할 사항
1. 검색시 마지막 한글자 지우면 렉걸림
2. 검색과 셀렉트 서로 초기화
3. 수식사전 포인터 커서 추가
4. height 반응형
5. 크롬 배포했을 때 image 나오게 해야함