### PR TITLE
#67 - 헤더 버튼 호버에서 클릭으로 수정

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8975,11 +8975,6 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "typesafe-actions": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/typesafe-actions/-/typesafe-actions-5.1.0.tgz",
-      "integrity": "sha512-bna6Yi1pRznoo6Bz1cE6btB/Yy8Xywytyfrzu/wc+NFW3ZF0I+2iCGImhBsoYYCOWuICtRO4yHcnDlzgo1AdNg=="
-    },
     "typescript": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",

--- a/client/src/components/Ingredients/DropDownItem/index.tsx
+++ b/client/src/components/Ingredients/DropDownItem/index.tsx
@@ -1,9 +1,13 @@
-import React, { ReactChildren } from 'react';
+import React, { ReactChildren, useRef } from 'react';
 import { LatexHeader, LatexContent } from '../../../lib/constants/latex-header';
 import * as S from './style';
+
 interface DropDownItemProps {
   children?: ReactChildren | string;
-  onMouseOver: (e: React.MouseEvent) => void;
+  formulaList: React.MutableRefObject<HTMLUListElement | null>;
+  onDisplayFormula: () => void;
+  onHiddenFormula: () => void;
+  nowHeader: string;
   setNowHeader: (header: string) => void;
   setNowFormula: (formula: LatexContent[]) => void;
   latex: LatexHeader;
@@ -11,21 +15,40 @@ interface DropDownItemProps {
 
 function DropDownItem({
   children,
-  onMouseOver,
   latex,
+  formulaList,
+  nowHeader,
+  onDisplayFormula,
+  onHiddenFormula,
   setNowHeader,
   setNowFormula,
 }: DropDownItemProps) {
-  const customMouseOver = (e: React.MouseEvent) => {
-    onMouseOver(e);
+  const itemRef = useRef<null | HTMLButtonElement>(null);
+
+  const onClickDropDownItem = () => {
+    if (!formulaList.current) return;
+
+    if (nowHeader !== latex.header) {
+      onDisplayFormula();
+    } else {
+      if (formulaList.current.style.display === 'none') {
+        onDisplayFormula();
+      } else {
+        onHiddenFormula();
+        if (itemRef.current) itemRef.current.blur();
+      }
+    }
     setNowFormula(latex.content);
     setNowHeader(latex.header);
   };
 
-  if (children) {
-    return <S.DropDownItemStyle onMouseOver={customMouseOver}>{children}</S.DropDownItemStyle>;
-  }
-  return <S.DropDownItemStyle header={latex.header} onMouseOver={customMouseOver} />;
+  return children ? (
+    <S.DropDownItemStyle ref={itemRef} onClick={onClickDropDownItem}>
+      {children}
+    </S.DropDownItemStyle>
+  ) : (
+    <S.DropDownItemStyle ref={itemRef} onClick={onClickDropDownItem} header={latex.header} />
+  );
 }
 
 export default DropDownItem;

--- a/client/src/components/Ingredients/DropDownItem/style.ts
+++ b/client/src/components/Ingredients/DropDownItem/style.ts
@@ -16,6 +16,10 @@ export const DropDownItemStyle = styled.button<DropDownItemStyleProps>`
   border: 4px solid transparent;
   background-repeat: no-repeat;
   filter: invert(28%) sepia(9%) saturate(10%) hue-rotate(1deg) brightness(91%) contrast(83%);
+  outline: 0;
+  &:focus {
+    border: 4px dashed #6d9eeb;
+  }
   &:hover {
     border: 4px dashed #6d9eeb;
   }

--- a/client/src/components/Meal/FormulaList/index.tsx
+++ b/client/src/components/Meal/FormulaList/index.tsx
@@ -6,19 +6,16 @@ import FormulaItem from '@ingredients/FormulaItem';
 import useFormulaList from './useFormulaList';
 import * as S from './style';
 import { RootState } from '@contexts/index';
-
 import { userLogin, userLogout } from '@contexts/user';
-import { getToken, setToken } from '@utils/token';
-import { Loader } from 'semantic-ui-react';
+import { setToken } from '@utils/token';
 
 function FormulaList() {
   const {
     formulaRef,
-    containerRef,
+    formulaHeaderRef,
+    symbolHeaderRef,
     displayFormula,
-    clearHiddenTimemout,
     hiddenFormula,
-    reserveHiddenFormula,
     nowHeader,
     setNowHeader,
     nowFormulas,
@@ -36,6 +33,7 @@ function FormulaList() {
       dispatch(userLogin(userId));
     });
   };
+
   const onClickLogoutHandler = async () => {
     chrome.storage.sync.clear();
     dispatch(userLogout());
@@ -43,31 +41,34 @@ function FormulaList() {
 
   return (
     <>
-      <S.FormulaContainer
-        ref={containerRef}
-        className="formula_container"
-        onMouseLeave={reserveHiddenFormula}
-      >
+      <S.FormulaContainer>
         <S.Logo />
 
         <S.HeaderWraaper>
-          <S.FormulaHeaderWrapper>
+          <S.FormulaHeaderWrapper ref={formulaHeaderRef}>
             {FORMULA_HEADER.map((latex, index) => (
               <DropDownItem
                 latex={latex}
                 key={index}
-                onMouseOver={displayFormula}
+                formulaList={formulaRef}
+                onHiddenFormula={hiddenFormula}
+                onDisplayFormula={displayFormula}
+                nowHeader={nowHeader}
                 setNowHeader={setNowHeader}
                 setNowFormula={setNowFormula}
               ></DropDownItem>
             ))}
           </S.FormulaHeaderWrapper>
-          <S.SymbolHeaderWrapper>
+
+          <S.SymbolHeaderWrapper ref={symbolHeaderRef}>
             {SYMBOL_HEADER.map((latex, index) => (
               <DropDownItem
                 latex={latex}
                 key={index}
-                onMouseOver={displayFormula}
+                formulaList={formulaRef}
+                onHiddenFormula={hiddenFormula}
+                onDisplayFormula={displayFormula}
+                nowHeader={nowHeader}
                 setNowHeader={setNowHeader}
                 setNowFormula={setNowFormula}
               >
@@ -76,19 +77,15 @@ function FormulaList() {
             ))}
           </S.SymbolHeaderWrapper>
         </S.HeaderWraaper>
+
         {userId ? (
           <S.LogoutButton onClick={onClickLogoutHandler} />
         ) : (
           <S.LoginButton onClick={onClickLoginHandler} />
         )}
       </S.FormulaContainer>
-      <S.FormulaList
-        ref={formulaRef}
-        onMouseLeave={hiddenFormula}
-        onMouseOver={clearHiddenTimemout}
-        length={nowFormulas.length}
-        header={nowHeader}
-      >
+
+      <S.FormulaList ref={formulaRef} length={nowFormulas.length} header={nowHeader}>
         {nowFormulas.map((latexInfo, index) => (
           <FormulaItem
             key={index}

--- a/client/src/components/Meal/FormulaList/style.ts
+++ b/client/src/components/Meal/FormulaList/style.ts
@@ -9,9 +9,11 @@ export const FormulaContainer = styled.div`
   background-color: #f3f3f3;
   height: 100%;
 `;
+
 export const HeaderWraaper = styled.div`
   display: flex;
 `;
+
 export const Logo = styled.div`
   width: 100px;
   background-color: darkblue;
@@ -26,6 +28,7 @@ export const LoginButton = styled.div`
   background-size: contain;
   background-repeat: no-repeat;
 `;
+
 export const LogoutButton = styled.div`
   background: url(${() => getImageURL('logout.png')});
   width: 100px;

--- a/client/src/components/Meal/FormulaList/useFormulaList.ts
+++ b/client/src/components/Meal/FormulaList/useFormulaList.ts
@@ -1,12 +1,11 @@
-import { useDispatch } from 'react-redux';
-import { useEffect, useRef, useState } from 'react';
+import { observer } from '@utils/util';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { LatexContent } from '../../../lib/constants/latex-header';
 
 const useFormulaList = () => {
   const formulaRef = useRef<null | HTMLUListElement>(null);
-  const containerRef = useRef<null | HTMLDivElement>(null);
-  const timer = useRef<any>(null);
-  const dispatch = useDispatch();
+  const formulaHeaderRef = useRef<null | HTMLDivElement>(null);
+  const symbolHeaderRef = useRef<null | HTMLDivElement>(null);
   const [nowHeader, setNowHeader] = useState('');
   const [nowFormulas, setNowFormula] = useState<LatexContent[]>([]);
 
@@ -22,34 +21,32 @@ const useFormulaList = () => {
     }
   };
 
-  const reserveHiddenFormula = () => {
-    timer.current = setTimeout(() => {
+  const hiddenFormulaOnPage = useCallback((target: HTMLElement) => {
+    console.log(target.closest('div'));
+    console.log(formulaHeaderRef.current);
+    console.log(symbolHeaderRef.current);
+    if (
+      target.closest('div') !== formulaHeaderRef.current &&
+      target.closest('div') !== symbolHeaderRef.current
+    ) {
       hiddenFormula();
-    }, 600);
-  };
-
-  const clearHiddenTimemout = () => {
-    clearTimeout(timer.current);
-  };
+    }
+  }, []);
 
   useEffect(() => {
-    document.body.addEventListener('mouseleave', () => {
-      clearHiddenTimemout();
-      hiddenFormula();
-    });
+    observer.subscribe(hiddenFormulaOnPage);
   }, []);
 
   return {
     formulaRef,
-    containerRef,
+    formulaHeaderRef,
+    symbolHeaderRef,
     nowFormulas,
     setNowFormula,
     nowHeader,
     setNowHeader,
     displayFormula,
-    clearHiddenTimemout,
     hiddenFormula,
-    reserveHiddenFormula,
   };
 };
 

--- a/client/src/components/Meal/FormulaList/useFormulaList.ts
+++ b/client/src/components/Meal/FormulaList/useFormulaList.ts
@@ -22,9 +22,6 @@ const useFormulaList = () => {
   };
 
   const hiddenFormulaOnPage = useCallback((target: HTMLElement) => {
-    console.log(target.closest('div'));
-    console.log(formulaHeaderRef.current);
-    console.log(symbolHeaderRef.current);
     if (
       target.closest('div') !== formulaHeaderRef.current &&
       target.closest('div') !== symbolHeaderRef.current


### PR DESCRIPTION
## 관련 이슈
- #67 - UI Refactoring

## 구현한 내용
- header 버튼들 hover에서 click로 수정
- header 버튼 다시 클릭시 focus 없애고, 수식 리스트도 꺼지도록 구현
- header 버튼 이외의 부분을 클릭시 수식 리스트 꺼지도록 구현

## 실행 화면
![image](https://user-images.githubusercontent.com/23556120/101515160-67549580-39c1-11eb-96f1-65e1478aae9b.png)
